### PR TITLE
Fix multiple bugs

### DIFF
--- a/Command/SonataImportCommand.php
+++ b/Command/SonataImportCommand.php
@@ -176,7 +176,7 @@ class SonataImportCommand extends ContainerAwareCommand {
     protected function setValue($value, FormBuilderInterface $formBuilder, AbstractAdmin $admin) {
 
         $mappings = $this->getContainer()->getParameter('doctrs_sonata_import.mappings');
-        $type = $formBuilder->getType()->getName();
+        $type = $formBuilder->getType();
 
         /**
          * Проверяем кастомные типы форм на наличие в конфиге.

--- a/Form/Type/UploadFileType.php
+++ b/Form/Type/UploadFileType.php
@@ -53,7 +53,7 @@ class UploadFileType extends AbstractType
         $loader = [];
         $loaders_list = $this->container->getParameter('doctrs_sonata_import.class_loaders');
         foreach ($loaders_list as $key => $item) {
-            $loader[$key] = $item['name'];
+            $loader[$item['name']] = $key;
         }
         $builder->add('loaderClass', ChoiceType::class, [
             'choices' => $loader,


### PR DESCRIPTION
I found these bugs when I used this bundle, I'm using Symfony v4.1.2 and PHP v7.1.11 on a Windows machine:
- ` $formBuilder->getType()->getName();` threw `Attempted to call an undefined method named "getValue" of class "Symfony\Component\Form\Extension\DataCollector\Proxy\ResolvedTypeDataCollectorProxy".` but after removing `->getName();` it worked fine.
- `UploadFile` injection didn't work for me as well, it threw string was given so I used the raw `$id` to get  `UploadFile` instance.
- `$form->isValid()` threw an exception if it was called before `$form->isSubmitted()`.
- On windows the `runCommand` method didn't work so I used the code in this tutorial to call the command from Symfony: https://symfony.com/doc/3.4/console/command_in_controller.html
- The `loader_class` column stored the name of the loader instead of the id and it threw `class_loader not found` error, so I swapped the key and value in the form.

I hope this helps, let me know if anything needs to be changed.

Thanks,